### PR TITLE
Show CD icon for cards without a back side

### DIFF
--- a/Rem Card Icon.css
+++ b/Rem Card Icon.css
@@ -10,14 +10,18 @@
 	--forward-practice-color: #FF2600;
 	--backward-practice-color: #D783FF;
 	--disabled-practice-color: #959595;
+	--no-practice-color: green;
 	--line-color: #DDDDDD;
 	--node-card-item-color: #FF4E4C;
 	--node-card-item-color-dark: #E0CD00;
 }
-
-.rem-container--backwards-practice-enabled.rem-container--forwards-practice-enabled .rem-bullet {
-	background: var(--both-practice-color);
-	width: 26px;
+.rem-container--concept-rem-type .rem-bullet,
+.rem-container--default_type-rem-type.rem-container--forwards-practice-enabled .rem-bullet,
+.rem-container--default_type-rem-type.rem-container--backwards-practice-enabled .rem-bullet,
+.rem-container--default_type-rem-type.rem-container--forwards-practice-disabled .rem-bullet
+ {
+    background: var(--no-practice-color);
+  	width: 26px;
 	height: 18px;
 	position: relative;
 	left: 6px;
@@ -28,54 +32,26 @@
 	-webkit-mask-repeat: no-repeat;
 	mask-repeat: no-repeat;
 	zoom: 80%;
+}
+
+.rem-container--backwards-practice-enabled.rem-container--forwards-practice-enabled .rem-bullet {
+	background: var(--both-practice-color);
 }
 
 .rem-container--backwards-practice-disabled.rem-container--forwards-practice-enabled .rem-bullet {
 	background: var(--forward-practice-color);
-	width: 26px;
-	height: 18px;
-	position: relative;
-	left: 6px;
-	-webkit-mask-image: url("https://browneyedsoul.github.io/ImageRepository/Concept.svg");
-	mask-image: url("https://browneyedsoul.github.io/ImageRepository/Concept.svg");
-	-webkit-mask-size: contain;
-	mask-size: contain;
-	-webkit-mask-repeat: no-repeat;
-	mask-repeat: no-repeat;
-	zoom: 80%;
 }
 
 .rem-container--forwards-practice-disabled .rem-bullet {
 	background: var(--disabled-practice-color);
-	width: 26px;
-	height: 18px;
-	position: relative;
-	left: 6px;
-	-webkit-mask-image: url("https://browneyedsoul.github.io/ImageRepository/Concept.svg");
-	mask-image: url("https://browneyedsoul.github.io/ImageRepository/Concept.svg");
-	-webkit-mask-size: contain;
-	mask-size: contain;
-	-webkit-mask-repeat: no-repeat;
-	mask-repeat: no-repeat;
-	zoom: 80%;
 }
 
 .rem-container--forwards-practice-disabled.rem-container--backwards-practice-enabled .rem-bullet {
 	background: var(--backward-practice-color);
-	width: 26px;
-	height: 18px;
-	position: relative;
-	left: 6px;
-	-webkit-mask-image: url("https://browneyedsoul.github.io/ImageRepository/Concept.svg");
-	mask-image: url("https://browneyedsoul.github.io/ImageRepository/Concept.svg");
-	-webkit-mask-size: contain;
-	mask-size: contain;
-	-webkit-mask-repeat: no-repeat;
-	mask-repeat: no-repeat;
-	zoom: 80%;
 }
 
 .rem-container--descriptor-rem-type .rem-bullet {
+    background: var(--no-practice-color);
 	width: 14px !important;
 	height: 12px !important;
 	position: relative !important;
@@ -83,20 +59,6 @@
 	left: -1px !important;
 	-webkit-mask-image: url("https://browneyedsoul.github.io/ImageRepository/Descriptor.svg");
 	mask-image: url("https://browneyedsoul.github.io/ImageRepository/Descriptor.svg");
-	-webkit-mask-size: contain;
-	mask-size: contain;
-	-webkit-mask-repeat: no-repeat;
-	mask-repeat: no-repeat;
-}
-
-.rem-container--descriptor-rem-type .rem-bullet {
-	width: 14px !important;
-	height: 12px !important;
-	position: relative !important;
-	top: 2px !important;
-	left: -1px !important;
-	-webkit-mask-image: url("https://browneyedsoul.github.io/ImageRepository/Descriptor.svg") !important;
-	mask-image: url("https://browneyedsoul.github.io/ImageRepository/Descriptor.svg") !important;
 	-webkit-mask-size: contain;
 	mask-size: contain;
 	-webkit-mask-repeat: no-repeat;


### PR DESCRIPTION
Previously a back side was required to make the icon show up. Now it is displayed on all .rem-container--concept-rem-type.

I tried to reduce duplication by moving the masking rules to a single block with `background: var(--no-practice-color)` as default color.
You may need to pick a good color here.

The concept icon is also used for plain cards. Do we want a different icon here?